### PR TITLE
Disable text selection of UI elements

### DIFF
--- a/css/ui.css
+++ b/css/ui.css
@@ -2,6 +2,11 @@ canvas {
   outline: none !important;
 }
 
+/* Disables text selection of UI elements */
+body {
+  user-select: none;
+}
+
 .tcv_cad_viewer {
   margin: 0;
   display: flex;

--- a/src/slider.js
+++ b/src/slider.js
@@ -53,6 +53,14 @@ class Slider {
   }
 
   sliderChange = (e) => {
+
+    // // Another option
+    // if (window.getSelection) {
+    //   window.getSelection().removeAllRanges();
+    // } else if (document.selection) {
+    //   document.selection.empty();
+    // }
+
     const value = e.target.value;
     this.input.value = Math.round(1000 * value) / 1000;
     this._handle(this.type, this.index, this.input.value);


### PR DESCRIPTION
Trying to move a slider while body elements are selected can cause the slider to lock on chromium-based browsers. Since none of the body needs to be copied, selection can be disabled entirely.

Try it: In Chrome, switch to the Clipping tab, press Ctrl+A, try to move a slider.

My original idea was just to de-select on sliderChange, I've included that option if more fine-grained control of user selection is needed.