### PR TITLE
Dispose anything with geometry or material

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -88,12 +88,7 @@ function deepDispose(tree) {
     tree.dispose();
   } else if (Array.isArray(tree)) {
     tree.forEach(deepDispose);
-  } else if (
-    tree.isMesh ||
-    tree.isLine ||
-    tree.isLineSegments ||
-    tree.isLineSegments2
-  ) {
+  } else if (tree.isMesh || tree.isLine) {
     disposeMesh(tree);
   }
 }


### PR DESCRIPTION
instanceof doesn't always recognize Mesh.
I'm really not sure why, could be caused by multiple dependencies being built against different threejs.

But this approach works for sure and improved memory consumption on my setup